### PR TITLE
document CE constructors in a way that circumvents the warnings

### DIFF
--- a/Flips/Domain.fs
+++ b/Flips/Domain.fs
@@ -278,12 +278,12 @@ module Builders =
         |> String.concat "_"
         |> (sprintf "%s_%s" prefix)
 
-    // note: the param for this constructor argument is correct, to the best of my knowledge, but the validation logic inside the compiler doesn't recognize it
-
     /// <summary>A Computation Expression for creating constraints with a predefined naming convention</summary>
-    /// <param name="constraintSetPrefix">The string which will be the prefix for all of the constraints</param>
-    /// <returns>A sequence of Constraints whith the given prefix and a unique name for each constraint</returns>
-    type ConstraintBuilder (constraintSetPrefix:string) =
+    type ConstraintBuilder
+        /// <summary>A Computation Expression for creating constraints with a predefined naming convention</summary>
+        /// <param name="constraintSetPrefix">The string which will be the prefix for all of the constraints</param>
+        /// <returns>A sequence of Constraints whith the given prefix and a unique name for each constraint</returns>
+         (constraintSetPrefix:string) =
 
         member this.Yield (cExpr:ConstraintExpression) =
             cExpr
@@ -298,12 +298,12 @@ module Builders =
         member this.Run(source:seq<'a * ConstraintExpression>) =
             source |> Seq.map (fun (n, c) -> Constraint.create (namer constraintSetPrefix n) c)
 
-    // note: the param for this constructor argument is correct, to the best of my knowledge, but the validation logic inside the compiler doesn't recognize it
-
     /// <summary>A Computation Expression for creating tuples of type ('Key * Decision)</summary>
-    /// <param name="decisionSetPrefix">The prefix used for naming the Decisions</param>
-    /// <returns>A seq of type ('Key * Decision). The result is typically used to create a Map or SliceMap</returns>
-    type DecisionBuilder (decisionSetPrefix:string) =
+    type DecisionBuilder
+        /// <summary>A Computation Expression for creating tuples of type ('Key * Decision)</summary>
+        /// <param name="decisionSetPrefix">The prefix used for naming the Decisions</param>
+        /// <returns>A seq of type ('Key * Decision). The result is typically used to create a Map or SliceMap</returns>
+        (decisionSetPrefix:string) =
 
         let createDecision indices decisionType =
             let name = namer decisionSetPrefix indices

--- a/Flips/UnitsOfMeasure.Domain.fs
+++ b/Flips/UnitsOfMeasure.Domain.fs
@@ -127,13 +127,15 @@ module Solution =
 
 [<AutoOpen>]
 module Builders =
-    // Note: this warning is because the compiler's detection for parameters is off for constructors. This is ok until that logic is fixed.
 
-    /// <summary>A Computation Expression for creating tuples of type (<typeparamref name="'Key"/> * Decision&lt;<typeparamref name="'Measure" />&gt;)</summary>
+    /// <summary>A Computation Expression for creating tuples of type (<typeparamref name="'Key"/> * <c>Decision</c>&lt;<typeparamref name="'Measure" />&gt;)</summary>
     /// <typeparam name="'Measure">The Unit of Measure for the Decisions</typeparam>
-    /// <param name="decisionSetPrefix">The prefix used for naming the Decisions</param>
-    /// <returns>A seq of type (<typeparamref name="'Key"/> * Decision&lt;<typeparamref name="'Measure" />&gt;). The result is typically used to create a Map or SliceMap</returns>
-    type DecisionBuilder<[<Measure>] 'Measure> (decisionSetPrefix:string) =
+    type DecisionBuilder<[<Measure>] 'Measure>
+        /// <summary>A Computation Expression for creating tuples of type (<typeparamref name="'Key"/> * Decision&lt;<typeparamref name="'Measure" />&gt;)</summary>
+        /// <typeparam name="'Measure">The Unit of Measure for the Decisions</typeparam>
+        /// <param name="decisionSetPrefix">The prefix used for naming the Decisions</param>
+        /// <returns>A seq of type (<typeparamref name="'Key"/> * Decision&lt;<typeparamref name="'Measure" />&gt;). The result is typically used to create a Map or SliceMap</returns>
+        (decisionSetPrefix:string) =
 
         let createDecision indices decisionType =
             let name = namer decisionSetPrefix indices


### PR DESCRIPTION
While working on https://github.com/dotnet/fsharp/pull/10810 to help improve doc comment generation, I found that the compiler wants you as a library author to separate docs for the type from docs for the implicit constructors. This does that, which fixes the documentation warnings.