### PR TITLE
Fix for stack overflow in LinearExpression.GetHashCode

### DIFF
--- a/Flips.Tests/Tests.fs
+++ b/Flips.Tests/Tests.fs
@@ -200,6 +200,11 @@ module Types =
             let r = expr + d - d
             Assert.Equal(expr, r)
 
+        [<Fact>]
+        let ``GetHashCode works correctly`` () =
+            LinearExpression.Empty.GetHashCode() |> ignore
+            (LinearExpression.OfFloat 1.0).GetHashCode() |> ignore
+
 
     [<Properties(Arbitrary = [| typeof<Types> |] )>]
     module ModelTests =

--- a/Flips/Types.fs
+++ b/Flips/Types.fs
@@ -259,7 +259,12 @@ and
 
 
     override this.GetHashCode () =
-        hash this
+        match this with
+        | Empty -> 0
+        | AddFloat (f, le) -> hash (f, le)
+        | AddDecision (f, d) -> hash (f, d)
+        | Multiply (f, le) -> hash (f, le)
+        | AddLinearExpression (le1, le2) -> hash (le1, le2)
 
     override this.Equals(obj) =
         match obj with


### PR DESCRIPTION
Fixes #132

...or at least I think it does.  I have not been able to confirm this.

This PR contains two commits.  The first commit adds a test that I was able to confirm reproduces the problem (the second line...wasn't able to confirm that first line also reproduces the issue).  The second commit presumably fixes the issue, but I was not able to confirm this.

My inability to confirm is due to inconsistent compilation results.  If someone else is able to that the test fails on the first commit (just to double check for good measure) and passes on the second commit, that would be greatly appreciated.