### PR TITLE
build project Flips when in debug

### DIFF
--- a/Flips.sln
+++ b/Flips.sln
@@ -98,6 +98,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FFE0CCDF-E1F1-47E5-8259-C5E4EE270D76}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{FFE0CCDF-E1F1-47E5-8259-C5E4EE270D76}.Debug|Any CPU.Build.0 = Debug|x64
 		{FFE0CCDF-E1F1-47E5-8259-C5E4EE270D76}.Debug|x64.ActiveCfg = Debug|x64
 		{FFE0CCDF-E1F1-47E5-8259-C5E4EE270D76}.Debug|x64.Build.0 = Debug|x64
 		{FFE0CCDF-E1F1-47E5-8259-C5E4EE270D76}.Release|Any CPU.ActiveCfg = Release|x64


### PR DESCRIPTION
I think I figured out why complication was inconsistent for me.  The `Flips` project did not specify that it should be built when in the debug configuration.

This PR configures the `Flips` project to built when in `debug` configuration.