### PR TITLE
Fix AddLinearExpression

### DIFF
--- a/Flips.Tests/Tests.fs
+++ b/Flips.Tests/Tests.fs
@@ -139,6 +139,16 @@ module Types =
             Assert.Equal(r1, r2)
 
         [<Property>]
+        let ``Multiplication then Addition of LinearExpression is associative`` () =
+          let numberOfDecisions = rng.Next(1, 100)
+          let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)
+          let expr1 = randomExpressionFromDecisions rng decisions
+          let expr2 = randomExpressionFromDecisions rng decisions
+          let r1 = 2.0 * (expr1 + expr2)
+          let r2 = 2.0 * expr2 + 2.0 * expr1
+          Assert.Equal(r1, r2)
+
+        [<Property>]
         let ``Addition of LinearExpression and float is commutative`` (SmallFloat f) =
             let numberOfDecisions = rng.Next(1, 100)
             let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)

--- a/Flips/Types.fs
+++ b/Flips/Types.fs
@@ -201,7 +201,7 @@ and
                 let newMultiplier = multiplier * nodeMultiplier
                 evaluateNode (newMultiplier, state) nodeExpr cont
             | AddLinearExpression (lExpr, rExpr) ->
-                evaluateNode (multiplier, state) lExpr (fun l -> evaluateNode l rExpr cont)
+                evaluateNode (multiplier, state) lExpr (fun (_, lState) -> evaluateNode (multiplier, lState) rExpr cont)
 
         let (_,reduceResult) = evaluateNode (1.0, initialState) expr id
 


### PR DESCRIPTION
This code:

```fsharp
let d = Decision.createBoolean "d1"
let e = 2.0 * (1.0 * d) + 1.0 * d
let r = LinearExpression.Reduce e
```

Produces

```terminal
val r : ReducedLinearExpression =
  { DecisionTypes = dict [(DecisionName "d1", Boolean)]
    Coefficients = dict [(DecisionName "d1", 4.0)]
    Offset = 0.0 }
```

But should produce this

```terminal
val r : ReducedLinearExpression =
  { DecisionTypes = dict [(DecisionName "d1", Boolean)]
    Coefficients = dict [(DecisionName "d1", 3.0)]
    Offset = 0.0 }
```
