### PR TITLE
Fix bug in LinearExpression.Evaluate

### DIFF
--- a/Flips.Tests/Tests.fs
+++ b/Flips.Tests/Tests.fs
@@ -148,23 +148,23 @@ module Types =
 
         [<Property>]
         let ``Left multiplication of floats is additive for LinearExpression addition`` (SmallFloat f) =
-          let numberOfDecisions = rng.Next(1, 100)
-          let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)
-          let expr1 = randomExpressionFromDecisions rng decisions
-          let expr2 = randomExpressionFromDecisions rng decisions
-          let r1 = f * (expr1 + expr2)
-          let r2 = f * expr2 + f * expr1
-          Assert.Equal(r1, r2)
+            let numberOfDecisions = rng.Next(1, 100)
+            let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)
+            let expr1 = randomExpressionFromDecisions rng decisions
+            let expr2 = randomExpressionFromDecisions rng decisions
+            let r1 = f * (expr1 + expr2)
+            let r2 = f * expr2 + f * expr1
+            Assert.Equal(r1, r2)
 
         [<Property>]
         let ``Right multiplication of floats is additive for LinearExpression addition`` (SmallFloat f) =
-          let numberOfDecisions = rng.Next(1, 100)
-          let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)
-          let expr1 = randomExpressionFromDecisions rng decisions
-          let expr2 = randomExpressionFromDecisions rng decisions
-          let r1 = (expr1 + expr2) * f
-          let r2 = expr2 * f + expr1 * f
-          Assert.Equal(r1, r2)
+            let numberOfDecisions = rng.Next(1, 100)
+            let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)
+            let expr1 = randomExpressionFromDecisions rng decisions
+            let expr2 = randomExpressionFromDecisions rng decisions
+            let r1 = (expr1 + expr2) * f
+            let r2 = expr2 * f + expr1 * f
+            Assert.Equal(r1, r2)
 
         [<Property>]
         let ``Addition of LinearExpression and float is commutative`` (SmallFloat f) =

--- a/Flips.Tests/Tests.fs
+++ b/Flips.Tests/Tests.fs
@@ -167,6 +167,28 @@ module Types =
             Assert.Equal(r1, r2)
 
         [<Property>]
+        let ``Left multiplication of floats is additive for LinearExpression addition when evaluated`` (SmallFloat f) =
+            let numberOfDecisions = rng.Next(1, 100)
+            let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)
+            let expr1 = randomExpressionFromDecisions rng decisions
+            let expr2 = randomExpressionFromDecisions rng decisions
+            let evaluate = LinearExpression.Evaluate (fun _ -> 1.0)
+            let r1 = evaluate <| f * (expr1 + expr2)
+            let r2 = evaluate <| f * expr2 + f * expr1
+            Assert.Equal(r1, r2)
+
+        [<Property>]
+        let ``Right multiplication of floats is additive for LinearExpression addition when evaluated`` (SmallFloat f) =
+            let numberOfDecisions = rng.Next(1, 100)
+            let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)
+            let expr1 = randomExpressionFromDecisions rng decisions
+            let expr2 = randomExpressionFromDecisions rng decisions
+            let evaluate = LinearExpression.Evaluate (fun _ -> 1.0)
+            let r1 = evaluate <| (expr1 + expr2) * f
+            let r2 = evaluate <| expr2 * f + expr1 * f
+            Assert.Equal(r1, r2)
+
+        [<Property>]
         let ``Addition of LinearExpression and float is commutative`` (SmallFloat f) =
             let numberOfDecisions = rng.Next(1, 100)
             let decisions = DecisionGen |> Gen.sample 0 numberOfDecisions |> Seq.distinctBy (fun x -> x.Name)

--- a/Flips/Domain.fs
+++ b/Flips/Domain.fs
@@ -112,7 +112,7 @@ module Objective =
     /// <param name="objective">The Objective to evaluate the resulting value for</param>
     /// <returns>A float which is the simplification of the LinearExpression</returns>
     let evaluate (solution:Solution) (objective:Objective) =
-        LinearExpression.Evaluate solution.DecisionResults objective.Expression
+        LinearExpression.Evaluate (fun d -> solution.DecisionResults.[d]) objective.Expression
 
 
 [<RequireQualifiedAccess>]
@@ -246,7 +246,7 @@ module Solution =
     /// <param name="expression">The LinearExpression to evaluate the resulting value for</param>
     /// <returns>A float which is the simplification of the LinearExpression</returns>
     let evaluate (solution:Solution) (expression:LinearExpression) =
-        LinearExpression.Evaluate solution.DecisionResults expression
+        LinearExpression.Evaluate (fun d -> solution.DecisionResults.[d]) expression
 
 
 [<AutoOpen>]

--- a/Flips/Flips.fsproj
+++ b/Flips/Flips.fsproj
@@ -37,6 +37,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Flips.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
       <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.0.0" PrivateAssets="All" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
         <PrivateAssets>all</PrivateAssets>

--- a/Flips/Solve.fs
+++ b/Flips/Solve.fs
@@ -108,7 +108,7 @@ module internal ORTools =
 
         {
             DecisionResults = decisionMap
-            ObjectiveResult = Flips.Types.LinearExpression.Evaluate decisionMap objective.Expression
+            ObjectiveResult = Flips.Types.LinearExpression.Evaluate (fun d -> decisionMap.[d]) objective.Expression
         }
 
 
@@ -314,7 +314,7 @@ module internal Optano =
 
         {
             DecisionResults = decisionMap
-            ObjectiveResult = Flips.Types.LinearExpression.Evaluate decisionMap objective.Expression
+            ObjectiveResult = Flips.Types.LinearExpression.Evaluate (fun d -> decisionMap.[d]) objective.Expression
         }
 
 

--- a/Flips/Types.fs
+++ b/Flips/Types.fs
@@ -233,7 +233,7 @@ and
                 let newState = (multiplier * nodeMultiplier, state)
                 evaluateNode newState nodeExpr cont
             | AddLinearExpression (lExpr, rExpr) ->
-                evaluateNode (multiplier, state) lExpr (fun l -> evaluateNode l rExpr cont)
+                evaluateNode (multiplier, state) lExpr (fun (_, lState) -> evaluateNode (multiplier, lState) rExpr cont)
             
 
         let (_,reduceResult) = evaluateNode (1.0, ResizeArray()) expr id

--- a/Flips/Types.fs
+++ b/Flips/Types.fs
@@ -216,7 +216,7 @@ and
             | AddLinearExpression (lExpr, rExpr) -> getRec (fun l -> getRec cont l rExpr) decisions lExpr
         getRec id Set.empty expr
 
-    static member internal Evaluate (decisionMap:Map<Decision, float>) (expr:LinearExpression) : float =
+    static member internal Evaluate (getDecisionCoef: Decision -> float) (expr:LinearExpression) : float =
 
         let rec evaluateNode (multiplier:float, state:ResizeArray<float>) (node:LinearExpression) cont =
             match node with
@@ -226,7 +226,7 @@ and
                 let newState = (multiplier, state) 
                 evaluateNode newState nodeExpr cont
             | AddDecision ((nodeCoef, nodeDecision), nodeExpr) ->
-                state.Add(multiplier * nodeCoef * decisionMap.[nodeDecision])
+                state.Add(multiplier * nodeCoef * getDecisionCoef nodeDecision)
                 let newState = (multiplier, state)
                 evaluateNode newState nodeExpr cont
             | Multiply (nodeMultiplier, nodeExpr) ->

--- a/Flips/UnitsOfMeasure.Domain.fs
+++ b/Flips/UnitsOfMeasure.Domain.fs
@@ -70,7 +70,7 @@ module Objective =
     let evaluate (solution:Types.Solution) (objective: Objective<'Measure>) =
         let (Objective.Value objective) = objective
         objective.Expression
-        |> Flips.Types.LinearExpression.Evaluate solution.DecisionResults
+        |> Flips.Types.LinearExpression.Evaluate (fun d -> solution.DecisionResults.[d])
         |> FSharp.Core.LanguagePrimitives.FloatWithMeasure<'Measure>
 
 
@@ -121,7 +121,7 @@ module Solution =
     /// <returns>A float with a Unit of Measure which is the simplification of the LinearExpression</returns>
     let evaluate (solution:Types.Solution) (expression:LinearExpression<'Measure>) =
         let (LinearExpression.Value expression) = expression
-        Flips.Types.LinearExpression.Evaluate solution.DecisionResults expression
+        Flips.Types.LinearExpression.Evaluate (fun d -> solution.DecisionResults.[d]) expression
         |> FSharp.Core.LanguagePrimitives.FloatWithMeasure<'Measure>
 
 


### PR DESCRIPTION
Fixes #153

I made two changes in order to keep the tests simple.  First, I mades things in the `Flips` project with `internal` scope visible to the `Flips.Tests` project.  Second, I weakened an argument type of the internal method `LinearExpression.Evaluate`.

It is unfortunate that these two new tests are essentially the same as the two tests above them.  This is caused by the equivalently duplicate code between `LinearExpression.Reduce` and `LinearExpression.Evaluate`.  I expect to remove that duplication one day, but not soon.