### PR TITLE
Fix warning due to deprecation of Solution.ObjectiveResult

### DIFF
--- a/Flips.Tests/Tests.fs
+++ b/Flips.Tests/Tests.fs
@@ -719,8 +719,8 @@ module Types =
             let decisions = DecisionBuilder "Test" { for n in names -> Boolean } |> SMap
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> decisions.[n], s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -885,8 +885,8 @@ module Types =
             let decisions = DecisionBuilder "Test" { for n in names -> Boolean } |> SMap2
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> decisions.[n], s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -1149,8 +1149,8 @@ module Types =
             let decisions = DecisionBuilder "Test" { for n in names -> Boolean } |> SMap3
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> decisions.[n], s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -1569,8 +1569,8 @@ module Types =
             let decisions = DecisionBuilder "Test" { for n in names -> Boolean } |> SMap4
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> decisions.[n], s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -2259,8 +2259,8 @@ module Types =
             let decisions = DecisionBuilder "Test" { for n in names -> Boolean } |> SMap5
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> decisions.[n], s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 

--- a/Flips.Tests/UnitsOfMeasure.Tests.fs
+++ b/Flips.Tests/UnitsOfMeasure.Tests.fs
@@ -353,8 +353,8 @@ module UnitsOfMeasureTests =
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> let (Decision.Value d) = decisions.[n]
                                                                                          d, float s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -372,8 +372,8 @@ module UnitsOfMeasureTests =
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> let (Decision.Value d) = decisions.[n]
                                                                                          d, float s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -391,8 +391,8 @@ module UnitsOfMeasureTests =
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> let (Decision.Value d) = decisions.[n]
                                                                                          d, float s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -410,8 +410,8 @@ module UnitsOfMeasureTests =
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> let (Decision.Value d) = decisions.[n]
                                                                                          d, float s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 
@@ -429,8 +429,8 @@ module UnitsOfMeasureTests =
             let decisionResults = uniqueValues |> List.map (fun (n, (Scalar.Value s)) -> let (Decision.Value d) = decisions.[n]
                                                                                          d, float s) |> Map.ofList
             let solution = {
-                ObjectiveResult = 0.0
-                DecisionResults = decisionResults
+                ObjectiveValue = 0.0
+                DecisionResultsMap = decisionResults
             }
 
             let resultValues = 

--- a/Flips/Solve.fs
+++ b/Flips/Solve.fs
@@ -107,8 +107,8 @@ module internal ORTools =
             |> Map.ofSeq
 
         {
-            DecisionResults = decisionMap
-            ObjectiveResult = Flips.Types.LinearExpression.Evaluate (fun d -> decisionMap.[d]) objective.Expression
+            DecisionResultsMap = decisionMap
+            ObjectiveValue = Flips.Types.LinearExpression.Evaluate (fun d -> decisionMap.[d]) objective.Expression
         }
 
 
@@ -313,8 +313,8 @@ module internal Optano =
             |> Map.ofSeq
 
         {
-            DecisionResults = decisionMap
-            ObjectiveResult = Flips.Types.LinearExpression.Evaluate (fun d -> decisionMap.[d]) objective.Expression
+            DecisionResultsMap = decisionMap
+            ObjectiveValue = Flips.Types.LinearExpression.Evaluate (fun d -> decisionMap.[d]) objective.Expression
         }
 
 

--- a/Flips/Types.fs
+++ b/Flips/Types.fs
@@ -384,11 +384,14 @@ type Objective = {
 }
 
 /// The results of the optimization if it was successful
-type Solution = {
-    DecisionResults : Map<Decision,float>
-    [<Obsolete("Please use the Objective.evaluate function instead")>]
-    ObjectiveResult : float
+type Solution = internal {
+    DecisionResultsMap : Map<Decision,float>
+    ObjectiveValue : float
 }
+    with
+        [<Obsolete("Please use the Objective.evaluate function instead")>]
+        member this.ObjectiveResult: float = this.ObjectiveValue
+        member this.DecisionResults: Map<Decision,float> = this.DecisionResultsMap
 
 /// The type of underlying solver to use
 type SolverType = 


### PR DESCRIPTION
* Rename the fields of Solution and made them internal.
* Expose them via properties with the deprecation on the ObjectiveResult.
* When ObjectiveResult is removed, the corresponding internal ObjectiveValue can be removed in the entire codebase as well as the public properties. Moreover, DecisionResultsMap can be renamed back to DecisionResults.