### PR TITLE
Add DevContainer spec for .NET 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
-    "name": "dotnet9.0",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+    "name": "dotnet8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
     "postCreateCommand": "dotnet tool restore",
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "dotnet9.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+    "postCreateCommand": "dotnet tool restore",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ionide.ionide-fsharp",
+                "tintoy.msbuild-project-tools",
+                "ms-dotnettools.csharp",
+                "github.vscode-github-actions",
+                "mhutchie.git-graph"
+            ]
+        }
+    },
+    "remoteEnv": {
+        "DOTNET_CLI_TELEMETRY_OPTOUT": "true",
+        "DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK": "true"
+    }
+}


### PR DESCRIPTION
- Add DevContainer spec using the .NET 8 DevContainer image.
- Restore .NET tools when creating the container.
- Include VSCode extensions for F#/.NET development.