### PR TITLE
Prepare release notes for 2.4.10

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,10 @@
-### 2.4.10 - Wednesday, May 8th, 2024
+### 2.4.10
 * Update to .NET 8
 * Remove x64 restriction
 * Change to FAKE build project
 * Update to latest Google.OrTools package
 * Add methods to pretty print linear and constraint expressions
+* Fix warning due to deprecation of Solution.ObjectiveResult
 
 ### 2.4.9 - Wednesday, October 19th, 2022
 * Fix problem with Units of Measure when multiplying float and LinearExpression


### PR DESCRIPTION
@davidglassborow, I checked the 2.4.10 release notes that I had provided some time last year. I just added one bullet point because I find the other changes are more dev-experience and the like (e. g. the DevContainer) and need not be in the release notes.
If you agree, I'd add a date to the 2.4.10 headline in the release notes in this PR, merge it, and push a 2.4.10 tag to publish a new package to nuget.org.