### PR TITLE
Push tag to GitHub

### DIFF
--- a/build/Build.fs
+++ b/build/Build.fs
@@ -218,6 +218,7 @@ let initTargets () =
 
         let tagName = sprintf "v%s" release.NugetVersion
         Git.Branches.tag "" tagName
+        Git.Branches.pushTag "" "origin" tagName
 
     // --------------------------------------------------------------------------------------
     // Run all targets by default. Invoke 'build -t <Target>' to override


### PR DESCRIPTION
@davidglassborow, 2.4.10 is out.
Publishing that version, I realised, that the `Publish` target missed to push the tag to GH as well. This PR fixes this.